### PR TITLE
Ensure electron-builder builds TypeScript output

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "electron .",
     "predev": "npm run build:ts",
     "build": "electron-builder",
+    "prebuild": "npm run build:ts",
     "build:ts": "electron-vite build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a prebuild script so the Electron bundle is compiled before packaging

## Testing
- not run (dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dbecd4a6cc83339ec4d48287ace428