### PR TITLE
Ensure TypeScript bundle builds during packaging

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -1,0 +1,43 @@
+const { spawn } = require('child_process');
+
+function runBuildTs() {
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(npmCommand, ['run', 'build:ts'], {
+      stdio: 'inherit',
+      shell: false,
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(true);
+      } else {
+        reject(new Error(`npm run build:ts exited with code ${code}`));
+      }
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+module.exports = {
+  appId: 'com.pseudo.zoom.secretary',
+  files: [
+    'dist/**/*',
+    'py/**/*',
+    'package.json',
+  ],
+  extraResources: [
+    {
+      from: 'py',
+      to: 'py',
+    },
+  ],
+  async beforeBuild() {
+    await runBuildTs();
+    return true;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prestart": "npm run build:ts",
     "dev": "electron .",
     "predev": "npm run build:ts",
-    "build": "electron-builder",
+    "build": "electron-builder --config electron-builder.config.cjs",
     "build:ts": "electron-vite build"
   },
   "dependencies": {
@@ -31,19 +31,5 @@
     "electron-vite": "^2.2.0",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3"
-  },
-  "build": {
-    "appId": "com.pseudo.zoom.secretary",
-    "files": [
-      "dist/**/*",
-      "py/**/*",
-      "package.json"
-    ],
-    "extraResources": [
-      {
-        "from": "py",
-        "to": "py"
-      }
-    ]
   }
 }


### PR DESCRIPTION
## Summary
- move the electron-builder configuration into a dedicated config file
- run `npm run build:ts` from a `beforeBuild` hook so packaging always has a compiled bundle
- update the build script to point to the new configuration file

## Testing
- npm install *(fails: native module `naudiodon` cannot be built in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbecd4a6cc83339ec4d48287ace428