### PR TITLE
Fix electron build output paths

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     entry: 'src/main/main.ts',
     vite: {
       build: {
-        outDir: 'dist/main',
+        outDir: resolve(__dirname, 'dist', 'main'),
         emptyOutDir: true,
         rollupOptions: {
           output: {
@@ -23,7 +23,7 @@ export default defineConfig({
     },
     vite: {
       build: {
-        outDir: 'dist/preload',
+        outDir: resolve(__dirname, 'dist', 'preload'),
         emptyOutDir: true,
         rollupOptions: {
           output: {
@@ -42,7 +42,7 @@ export default defineConfig({
     },
     plugins: [react()],
     build: {
-      outDir: '../../dist/renderer',
+      outDir: resolve(__dirname, 'dist', 'renderer'),
       emptyOutDir: true,
       rollupOptions: {
         input: {


### PR DESCRIPTION
## Summary
- ensure electron-vite writes compiled main, preload, and renderer bundles into the dist directory expected by Electron and the build pipeline

## Testing
- not run (npm install fails in this environment due to registry restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68dd18466288833398f6a5c97056b6bb