### PR TITLE
Fix Windows spawn options for build hook

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -1,12 +1,13 @@
 const { spawn } = require('node:child_process');
 
 function runBundle() {
-  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const npmCommand = 'npm';
+  const useShell = process.platform === 'win32';
 
   return new Promise((resolve, reject) => {
     const child = spawn(npmCommand, ['run', 'build'], {
       stdio: 'inherit',
-      shell: false,
+      shell: useShell,
     });
 
     child.on('close', (code) => {


### PR DESCRIPTION
## Summary
- ensure the electron-builder beforeBuild hook invokes npm through the Windows shell to avoid spawn EINVAL errors

## Testing
- npm run build *(fails in container: electron-vite not found because native dependency `naudiodon` could not be compiled)*

------
https://chatgpt.com/codex/tasks/task_e_68deabbc57b08333bc9f1e21dbc235a1