### PR TITLE
Fix electron-builder output directory conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 out/
+release/
 *.log
 .DS_Store
 py/.venv/

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -26,6 +26,9 @@ function runBundle() {
 
 module.exports = {
   appId: 'com.pseudo.zoom.secretary',
+  directories: {
+    output: 'release',
+  },
   files: ['dist/**/*', 'py/**/*', 'package.json'],
   extraResources: [
     {


### PR DESCRIPTION
## Summary
- configure electron-builder to emit build artifacts into a dedicated `release` directory so the `dist` folder with compiled sources is preserved during packaging
- ignore the new `release` directory in version control

## Testing
- npm install *(fails: npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deaf962c588333ab2e0f10e0bd1463